### PR TITLE
Index: update cheatsheet URL

### DIFF
--- a/index.md
+++ b/index.md
@@ -448,7 +448,7 @@ other console/curses tools
 
 - [Ledger manuals](http://ledger-cli.org/docs.html)
 - [Ledger wiki](https://github.com/ledger/ledger/wiki)
-- [The Great Cheatsheet for Ledger CLI](http://ricostacruz.com/cheatsheets/ledger.html)
+- [The Great Cheatsheet for Ledger CLI](https://devhints.io/ledger)
 - [Getting Started With Ledger](https://github.com/rolfschr/GSWL-book/releases/latest)
 - [hledger User Guide](http://hledger.org/docs.html)
 - [Beancount docs](http://furius.ca/beancount/doc/index) ([sphinx version](http://aumayr.github.io/beancount-docs-static/))


### PR DESCRIPTION
http://ricostacruz.com/cheatsheets is now https://devhints.io :) (The old URL's are still accessible for now.)

See: https://devhints.io/ledger