### PR TITLE
Fix unintended line breaks in "API access" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -693,12 +693,12 @@ down 2018/03/14 - [Command Line Probate blog](https://commandlineprobate.com) --
 </ul>
 <h4 id="api-access">API access</h4>
 <ul>
-<li><p><a href="http://ledger-cli.org/3.0/doc/ledger3.html#Extending-with-Python">Ledger: Extending with Python</a></p></li>
-<li><p><a href="https://groups.google.com/forum/#!topic/ledger-cli/C99w-79Jq8o">Ledger Python 3 Support</a> Python</p></li>
-<li><p><a href="https://github.com/Rudd-O/ledgerhelpers">ledgerhelpers</a> Python</p></li>
-<li><p><a href="http://hackage.haskell.org/package/hledger-lib">hledger-lib</a>, <a href="http://hackage.haskell.org/package/hledger">hledger</a>, <a href="http://stefanorodighiero.net/posts/2015-01-04-hledger-find-duplicate-accounts.html">an example</a> Haskell</p></li>
-<li><p><a href="http://editor.swagger.io/#/?import=demo.hledger.org/api/swagger.json&amp;no-proxy">hledger-api</a>, <a href="https://github.com/simonmichael/hledger/tree/master/hledger-api/examples">examples</a> JSON</p></li>
-<li><p><a href="https://github.com/rstacruz/node-hledger">node-hledger</a> JavaScript</p></li>
+<li><a href="http://ledger-cli.org/3.0/doc/ledger3.html#Extending-with-Python">Ledger: Extending with Python</a></li>
+<li><a href="https://groups.google.com/forum/#!topic/ledger-cli/C99w-79Jq8o">Ledger Python 3 Support</a> Python</li>
+<li><a href="https://github.com/Rudd-O/ledgerhelpers">ledgerhelpers</a> Python</li>
+<li><a href="http://hackage.haskell.org/package/hledger-lib">hledger-lib</a>, <a href="http://hackage.haskell.org/package/hledger">hledger</a>, <a href="http://stefanorodighiero.net/posts/2015-01-04-hledger-find-duplicate-accounts.html">an example</a> Haskell</li>
+<li><a href="http://editor.swagger.io/#/?import=demo.hledger.org/api/swagger.json&amp;no-proxy">hledger-api</a>, <a href="https://github.com/simonmichael/hledger/tree/master/hledger-api/examples">examples</a> JSON</li>
+<li><a href="https://github.com/rstacruz/node-hledger">node-hledger</a> JavaScript</li>
 </ul>
 </div>
 </div>

--- a/index.md
+++ b/index.md
@@ -735,20 +735,15 @@ down 2018/03/14 - [Command Line Probate blog](https://commandlineprobate.com) --
 #### API access
 
 - [Ledger: Extending with Python](http://ledger-cli.org/3.0/doc/ledger3.html#Extending-with-Python)
-
 - [Ledger Python 3 Support](https://groups.google.com/forum/#!topic/ledger-cli/C99w-79Jq8o) Python
-
 - [ledgerhelpers](https://github.com/Rudd-O/ledgerhelpers) Python
-
 - [hledger-lib](http://hackage.haskell.org/package/hledger-lib),
   [hledger](http://hackage.haskell.org/package/hledger),
   [an example](http://stefanorodighiero.net/posts/2015-01-04-hledger-find-duplicate-accounts.html)
   Haskell
-
 - [hledger-api](http://editor.swagger.io/#/?import=demo.hledger.org/api/swagger.json&no-proxy),
   [examples](https://github.com/simonmichael/hledger/tree/master/hledger-api/examples)
   JSON
-
 - [node-hledger](https://github.com/rstacruz/node-hledger) JavaScript
 
 


### PR DESCRIPTION
The bullet points in the "API access" section are separated by newlines
in the source markdown. Unfortunately, this confuses the renderer in
such a way that in the published site the text appears *below* the
bullet point rather than next to it.

Removing the blank lines between bullet points fixes this.

**Before**
![screenshot from 2018-11-25 12-31-00](https://user-images.githubusercontent.com/25445/48982265-23c6b180-f0ae-11e8-96b8-bcfd4f435adb.png)

**After**
![screenshot from 2018-11-25 12-31-04](https://user-images.githubusercontent.com/25445/48982267-288b6580-f0ae-11e8-8d6e-4a9c4e96a220.png)
