### PR TITLE
Exclude README and CONTRIBUTING from automatic HTML conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: html
 
 # generate html from all md files
-html: $(patsubst %.md,%.html,$(wildcard *.md quickref/*.md)) Makefile
+html: $(patsubst %.md,%.html,$(filter-out README.md CONTRIBUTING.md,$(wildcard *.md quickref/*.md))) Makefile
 
 PANDOC=pandoc -f markdown-smart+autolink_bare_uris
 


### PR DESCRIPTION
When running `make` to generate the HTML version of the site, all
Markdown files are automatically found and converted - including
README.md and CONTRIBUTING.md.

These two aren't really wanted, and the resulting HTML versions need to
be ignored or deleted. It's not sufficient to add them to .gitignore,
because they'll still be there in the filesystem causing confusion, even
if the risk of committing them to Git is minimized.

This change filters them out of the Makefile's argument list of Markdown
files that should be automatically converted to HTML, so the unwanted
versions don't get generated in the first place.

**One important caveat** is that I personally don't know whether this
helper function is only available in GNU Make or is also present in the BSD
version (the manual pages I can find online aren't clarifying). I don't know
if portability is a goal of the Makefile in the first place, or whether it is currently
portable, but if it is, this change should probably be tested on a BSD Make.

Before:

```
$ make
pandoc -f markdown-smart+autolink_bare_uris --template index.tmpl CONTRIBUTING.md -o CONTRIBUTING.html
pandoc -f markdown-smart+autolink_bare_uris --template index.tmpl README.md -o README.html
```

After:

```
$ make
make: Nothing to be done for 'all'.
```