### PR TITLE
Update info of Tackler (new release, new hosting location)

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,10 +204,6 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td></td>
 <td style="text-align: center;"></td>
 <td></td>
-<td style="text-align: right;"></td>
-<td style="text-align: right;"></td>
-<td></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><a href="https://github.com/hrj/abandon#readme">Abandon</a></td>
@@ -240,14 +236,14 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td><a href="https://gitter.im/feramhq/transity">gitter</a></td>
 </tr>
 <tr class="even">
-<td><a href="https://github.com/sn127/tackler#readme">Tackler</a></td>
+<td><a href="https://gitlab.com/e257/accounting/tackler#readme">Tackler</a></td>
 <td>2017</td>
-<td style="text-align: center;">2018-01</td>
-<td><a href="https://github.com/sn127/tackler">scala</a></td>
+<td style="text-align: center;">2018-12</td>
+<td><a href="https://gitlab.com/e257/accounting/tackler">scala</a></td>
 <td style="text-align: right;">1</td>
 <td style="text-align: right;">14</td>
 <td></td>
-<td><a href="https://gitter.im/sn127/tackler">gitter</a></td>
+<td></td>
 </tr>
 <tr class="odd">
 <td><a href="https://github.com/dmitry-merzlyakov/nledger">.Net Ledger</a></td>
@@ -264,19 +260,11 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td></td>
 <td style="text-align: center;"></td>
 <td></td>
-<td style="text-align: right;"></td>
-<td style="text-align: right;"></td>
-<td></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><strong>Inactive:</strong></td>
 <td></td>
 <td style="text-align: center;"></td>
-<td></td>
-<td style="text-align: right;"></td>
-<td style="text-align: right;"></td>
-<td></td>
 <td></td>
 </tr>
 <tr class="even">
@@ -284,70 +272,42 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td>2015</td>
 <td style="text-align: center;"></td>
 <td><a href="https://github.com/danpat/uledger">python</a></td>
-<td style="text-align: right;"></td>
-<td style="text-align: right;"></td>
-<td></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td>pacioli</td>
 <td>2013</td>
 <td style="text-align: center;"></td>
 <td><a href="https://github.com/mdipierro/pacioli">python</a></td>
-<td style="text-align: right;"></td>
-<td style="text-align: right;"></td>
-<td></td>
-<td></td>
 </tr>
 <tr class="even">
 <td>ledger.pl</td>
 <td>2013</td>
 <td style="text-align: center;"></td>
 <td><a href="https://github.com/dimonf/ledger.pl">perl</a></td>
-<td style="text-align: right;"></td>
-<td style="text-align: right;"></td>
-<td></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><a href="http://massysett.github.io/penny/">Penny</a></td>
 <td>2012</td>
 <td style="text-align: center;">2014</td>
 <td><a href="https://github.com/massysett/penny">haskell</a></td>
-<td style="text-align: right;"></td>
-<td style="text-align: right;"></td>
-<td></td>
-<td></td>
 </tr>
 <tr class="even">
 <td><a href="http://hackage.haskell.org/package/UMM">UMM</a></td>
 <td>2009</td>
 <td style="text-align: center;">2010</td>
 <td><a href="http://hackage.haskell.org/package/UMM">haskell</a></td>
-<td style="text-align: right;"></td>
-<td style="text-align: right;"></td>
-<td></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td>cl-ledger</td>
 <td>2007</td>
 <td style="text-align: center;"></td>
 <td><a href="https://github.com/ledger/cl-ledger">common lisp</a></td>
-<td style="text-align: right;"></td>
-<td style="text-align: right;"></td>
-<td></td>
-<td></td>
 </tr>
 <tr class="even">
 <td>sm-Ledger</td>
 <td>2007</td>
 <td style="text-align: center;"></td>
 <td><a href="https://gist.github.com/simonmichael/bb611dba654ccb1573e1">squeak smalltalk</a></td>
-<td style="text-align: right;"></td>
-<td style="text-align: right;"></td>
-<td></td>
-<td></td>
 </tr>
 </tbody>
 </table>

--- a/index.md
+++ b/index.md
@@ -239,7 +239,7 @@ Project        | Start | Last release | Code                      | Committers |
 [Abandon]      | 2013  | 2017-05      | [scala][abandon-gh]       | 9          |  133  |                                  | [gitter][abandon-gi]
 [Ledger in Go] | 2013  | 2018-06      | [go][ledger-go-gh]        | 5          |  165  |                                  |
 [Transity]     | 2018  | 2018-09      | [purescript][transity-gh] | 4          |  374  |                                  | [gitter][transity-gi]
-[Tackler]      | 2017  | 2018-01      | [scala][tackler-gh]       | 1          |   14  |                                  | [gitter][tackler-gi]
+[Tackler]      | 2017  | 2018-12      | [scala][tackler-gl]       | 1          |   14  |                                  |
 [.Net Ledger]  | 2017  | 2018-08      | [C#][nledger-gh]          | 1          |   26  |                                  | [gitter][nledger-gi]
 &nbsp;         |       |              |
 **Inactive:**  |       |              |
@@ -290,9 +290,8 @@ sm-Ledger      | 2007  |              | [squeak smalltalk][smalltalk-gh]
 
 [smalltalk-gh]: https://gist.github.com/simonmichael/bb611dba654ccb1573e1
 
-[Tackler]: https://github.com/sn127/tackler#readme
-[tackler-gh]: https://github.com/sn127/tackler
-[tackler-gi]: https://gitter.im/sn127/tackler
+[Tackler]: https://gitlab.com/e257/accounting/tackler#readme
+[tackler-gl]: https://gitlab.com/e257/accounting/tackler
 
 [Transity]: https://github.com/feramhq/transity#readme
 [transity-gh]: https://github.com/feramhq/transity


### PR DESCRIPTION
Update info of Tackler and record new release and hosting location.

There are also some removed empty table cells, which were removed right after `pull && make`, e.g. before any modifications. So I left those there. Hopefully that's ok.