### PR TITLE
Add browser based ledger-like link

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@ Plain Text Accounting
 <p><strong>Who is this for?</strong><br />
 Those who are comfortable on the command line and who understand the value of storing information in plain text. If you need a complete GUI providing lots of guidance, you may prefer to use something else.</p>
 <p><strong>Must I edit text and type cryptic commands?</strong><br />
-Not entirely! &quot;Plain Text Accounting&quot; is a broad description, referring mainly to the data format. We welcome optional <strong><a href="#ui-console">GUIs</a></strong>, and they are <a href="#ui-console">coming</a>.</p>
+Not entirely! "Plain Text Accounting" is a broad description, referring mainly to the data format. We welcome optional <strong><a href="#ui-console">GUIs</a></strong>, and they are <a href="#ui-console">coming</a>.</p>
 <p><strong>Who is using this, and how?</strong><br />
 See <strong><a href="https://github.com/ledger/ledger/wiki/Who&#39;s-using-ledger%3F">Who's using Ledger?</a></strong> for some stories.</p>
 <p><strong>What are the alternatives?</strong><br />
@@ -118,23 +118,23 @@ You can use this to track and report the data needed for tax reporting. Fill out
 <p><strong>How do I do budgeting?</strong><br />
 See <a href="#budgeting">budgeting</a> below. I emulate YNAB-ish envelope budgetting (see third link).</p>
 <p><strong>Double entry accounting? Where are the debits and credits?</strong><br />
-Most (not all) plain text accounting implementations use signed amounts instead of debits and credits. This makes them &quot;double entry light&quot; perhaps, but it has been a rather successful simplification, intuitive to most newcomers.</p>
+Most (not all) plain text accounting implementations use signed amounts instead of debits and credits. This makes them "double entry light" perhaps, but it has been a rather successful simplification, intuitive to most newcomers.</p>
 <!-- (from <https://news.ycombinator.com/item?id=12124890>:) -->
 <p><strong>Isn't personal accounting a waste of time?</strong><br />
-People have very different needs and practise personal accounting for many different reasons. There is of course a point of diminishing returns; tailor your accounting practices to your needs. Needs change over time. Some of us would benefit from doing more (or better) accounting, some less (I would guess this second group is smaller). In <a href="https://en.wikipedia.org/wiki/The_Millionaire_Next_Door">The Millionaire Next Door</a> (highly recommended), one research finding was that above-average wealth accumulators spend more time on financial planning, which for many of us requires accounting as a foundation. &quot;Minimal time dedicated to financial planning is a leading indicator of a UAW [Under Accumulator of Wealth]&quot;.</p>
+People have very different needs and practise personal accounting for many different reasons. There is of course a point of diminishing returns; tailor your accounting practices to your needs. Needs change over time. Some of us would benefit from doing more (or better) accounting, some less (I would guess this second group is smaller). In <a href="https://en.wikipedia.org/wiki/The_Millionaire_Next_Door">The Millionaire Next Door</a> (highly recommended), one research finding was that above-average wealth accumulators spend more time on financial planning, which for many of us requires accounting as a foundation. "Minimal time dedicated to financial planning is a leading indicator of a UAW [Under Accumulator of Wealth]".</p>
 <p><strong>Do you really enter every little transaction?</strong><br />
 Yes! Many folks in our community do it. Mahatma Gandhi reconciled to the penny every night. J.D. Rockefeller was famous for his ledgers. It's not required. I started doing it as a temporary learning exercise, and still like it. It makes troubleshooting and reconciling easier.</p>
 <p><strong>How is that possible?</strong><br />
-Practice, and a process/toolset that suits you. Some folks import most of the data from their banks, so little manual data entry is required. A few prefer to manually enter everything, for the increased awareness and insight. &quot;Manual&quot; data entry is usually assisted in some way: interactive console tools (hledger add and similar), web-based tools (hledger-web and similar), GUI tools (ledgerhelpers), smart editors (eg emacs &amp; ledger-mode), recurring transaction scripts. I currently use a mixture of bank CSV import and rapid copy/paste in emacs. I spend 15 minutes a day on average, and for me that's currently a good investment.</p>
+Practice, and a process/toolset that suits you. Some folks import most of the data from their banks, so little manual data entry is required. A few prefer to manually enter everything, for the increased awareness and insight. "Manual" data entry is usually assisted in some way: interactive console tools (hledger add and similar), web-based tools (hledger-web and similar), GUI tools (ledgerhelpers), smart editors (eg emacs &amp; ledger-mode), recurring transaction scripts. I currently use a mixture of bank CSV import and rapid copy/paste in emacs. I spend 15 minutes a day on average, and for me that's currently a good investment.</p>
 <p><strong>How do I use the transaction data in my bank's web or mobile app?</strong><br />
 If you can export it as CSV, you can import it and run queries against it. There are also some tools for converting OFX, QIF etc.</p>
 <p><strong>So I've got a huge list of transactions recorded, duplicating my bank statements. How does that help?</strong><br />
 Accounting is modelling flows of money (or other value). Such a model aggregates information from many sources, in one trusted place. With it you can efficiently generate reports, forecast things (cashflow!), answer questions, try experiments. Some people need a very simple model, others benefit from a more detailed one, and we don't know up front what we might need in future. The most fundamental accounting data is a simple list of transactions (the journal). Once you have captured this, you can mine it for anything you may want later on. Plain text accounting provides nice open data format(s), tools and practices for doing this, and could be a good foundation for more powerful tools.</p>
 <p><strong>Isn't a command-line tool too limited for real-world accounting needs?</strong><br />
-<em>&quot;I am sure for a simple expense/budget ledger it will work OK, but when it comes to recurring journals, multiple reconciliation accounts, inter company transfers, control account tracing etc., give me a nice GUI any day...&quot;</em><br />
+<em>"I am sure for a simple expense/budget ledger it will work OK, but when it comes to recurring journals, multiple reconciliation accounts, inter company transfers, control account tracing etc., give me a nice GUI any day..."</em><br />
 Understandable. The current plain text accounting tools provide a very generic double entry accounting system with which you can model such things, and script them. There are a number of generic GUIs available (hledger has curses and web interfaces, and there are web/curses/GTK interfaces for Ledger and beancount). But there are not yet a lot of rich task-specific GUIs. There's no reason they can't be built, though.</p>
 <p><strong>Isn't a plain text format too limited for large organizations?</strong><br />
-<em>&quot;it's pretty obvious that plain-text files don't scale to a multinational, with hundreds of accountants of various types all trying to work with the same files. Even with proper use of Git I bet that would get old fast. You would instead want a real database, with a schema, and some data validation and some programs/webpages to smooth out the data entry and querying and whatnot.&quot;</em><br />
+<em>"it's pretty obvious that plain-text files don't scale to a multinational, with hundreds of accountants of various types all trying to work with the same files. Even with proper use of Git I bet that would get old fast. You would instead want a real database, with a schema, and some data validation and some programs/webpages to smooth out the data entry and querying and whatnot."</em><br />
 I'm not sure. Current plain text accounting tools can do some schema definition and data validation, and will do more in future. The plain text storage format is open, human-readable, future-proof (useful even without the software), scales smoothly from simple to complex needs, and taps a huge ecosystem of highly useful tooling, such as version control systems. And, despite the name, there's no reason these tools can't support other kinds of storage, such as a database.</p>
 <p><strong>Where can I see a comparison of hledger, Ledger, beancount, and the rest?</strong><br />
 Glad you asked! See below, and also <a href="#comparisons">comparisons</a>. hledger's FAQ discusses differences from Ledger, Beancount docs probably do too.</p>
@@ -262,6 +262,16 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td><a href="https://gitter.im/nledger/lobby">gitter</a></td>
 </tr>
 <tr class="even">
+<td><a href="https://monescript.github.io/">monescript</a></td>
+<td>2017</td>
+<td style="text-align: center;">2018-01</td>
+<td><a href="https://github.com/monescript/monescript">javascript</a></td>
+<td style="text-align: right;">1</td>
+<td style="text-align: right;">3</td>
+<td></td>
+<td></td>
+</tr>
+<tr class="odd">
 <td><a href="https://gitlab.com/e257/accounting/tackler#readme">Tackler</a></td>
 <td>2017</td>
 <td style="text-align: center;">2018-12</td>
@@ -271,7 +281,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td></td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td> </td>
 <td></td>
 <td style="text-align: center;"></td>
@@ -281,7 +291,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td></td>
 <td></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><strong>Inactive:</strong></td>
 <td></td>
 <td style="text-align: center;"></td>
@@ -291,7 +301,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td></td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>uledger</td>
 <td>2015</td>
 <td style="text-align: center;"></td>
@@ -301,7 +311,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td></td>
 <td></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>pacioli</td>
 <td>2013</td>
 <td style="text-align: center;"></td>
@@ -311,7 +321,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td></td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>ledger.pl</td>
 <td>2013</td>
 <td style="text-align: center;"></td>
@@ -321,7 +331,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td></td>
 <td></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="http://massysett.github.io/penny/">Penny</a></td>
 <td>2012</td>
 <td style="text-align: center;">2014</td>
@@ -331,7 +341,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td></td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><a href="http://hackage.haskell.org/package/UMM">UMM</a></td>
 <td>2009</td>
 <td style="text-align: center;">2010</td>
@@ -341,7 +351,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <td></td>
 <td></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>sm-Ledger</td>
 <td>2007</td>
 <td style="text-align: center;"></td>
@@ -359,7 +369,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <div class="row">
 
 <div class="seven columns">
-<h4 id="add-ons">add-ons</h4><p>This and the following sections collect add-ons and helper tools related to the above. &quot;*ledger&quot; below means Ledger &amp; hledger-style journal format.</p><ul>
+<h4 id="add-ons">add-ons</h4><p>This and the following sections collect add-ons and helper tools related to the above. "*ledger" below means Ledger &amp; hledger-style journal format.</p><ul>
 <li><a href="http://hackage.haskell.org/package/hledger-diff">hledger-diff</a> report differing transactions between two journals</li>
 <li><a href="http://hackage.haskell.org/package/hledger-interest">hledger-interest</a> generate *ledger interest transactions</li>
 <li><a href="http://hackage.haskell.org/package/hledger-irr">hledger-irr</a> calculate an account's internal rate of return (superseded by <a href="http://hledger.org/manual.html#roi">roi</a>)</li>

--- a/index.md
+++ b/index.md
@@ -244,6 +244,7 @@ Project        | Start | Last release | Code                        | Committers
 [Ledger in Go] | 2013  | 2018-06      | [go][ledger-go-gh]          | 5          |  168  |                                  |
 cl-ledger      | 2007  |              | [common lisp][cl-ledger-gh] | 4          |   50  |                                  | 
 [.Net Ledger]  | 2017  | 2018-08      | [C#][nledger-gh]            | 1          |   29  |                                  | [gitter][nledger-gi]
+[monescript]   | 2017  | 2018-01      | [javascript][monescript-gh] | 1          |    3  |                                  |
 [Tackler]      | 2017  | 2018-12      | [scala][tackler-gl]         | 1          |    0  |                                  |
 &nbsp;         |       |              |
 **Inactive:**  |       |              |
@@ -292,6 +293,9 @@ sm-Ledger      | 2007  |              | [squeak smalltalk][smalltalk-gh]
 [penny-gh]: https://github.com/massysett/penny
 
 [smalltalk-gh]: https://gist.github.com/simonmichael/bb611dba654ccb1573e1
+
+[monescript]: https://monescript.github.io/
+[monescript-gh]: https://github.com/monescript/monescript
 
 [Tackler]: https://gitlab.com/e257/accounting/tackler#readme
 [tackler-gl]: https://gitlab.com/e257/accounting/tackler


### PR DESCRIPTION
Adding a link for another ledger-like [monescript](https://github.com/monescript/monescript) working completely inside the browser. Hopefully this will allow to promote plain text accounting for the systems without robust command line environment. Still planning to continue working on it, so adding it to the active list.

Change was generated according to [guidelines](https://github.com/plaintextaccounting/plaintextaccounting.github.io/blob/master/CONTRIBUTING.md) using pandoc and make on Windows 10. Let me know if any questions.

Thanks for your time!