### PR TITLE
Add a link to the slc CLI app

### DIFF
--- a/index.html
+++ b/index.html
@@ -718,7 +718,6 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <li><a href="https://gitlab.com/egh/ledger-autosync">ledger-autosync</a> OFX download, OFX to *ledger conversion, deduplication</li>
 <li><a href="https://github.com/j3k0/ledger-guesser">ledger-guesser</a> neural network for generating entries like past ones, can be used with ledger-autosync (javascript)</li>
 <li><a href="https://github.com/ony/ledger-myexpenses">ledger-myexpenses</a> MyExpenses android app sqlite db to *ledger conversion (python)</li>
-<li><a href="https://disjoint.ca/projects/ledger-reconciler">ledger-reconciler</a> automatically download and reconcile your ledger financial entries</li>
 <li><a href="https://github.com/glasserc/ledger-to-beancount/">ledger-to-beancount</a> yet another simple ledger to beancount converter (python)</li>
 <li><a href="https://github.com/tlvince/ledger-tutorials">ledger-tutorials</a> convert Pete Keen's tutorials to ebook format</li>
 <li><a href="https://gist.github.com/travisdahlke/71152286b0a8826249fe">ledger2beancount.py</a> *ledger to beancount converter</li>

--- a/index.html
+++ b/index.html
@@ -729,7 +729,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <li><a href="https://gist.github.com/genegoykhman/3765100">qb2ledger</a> QuickBooks General Journal CSV to *ledger converter</li>
 <li><a href="https://github.com/Kolomona/QIFtoLedger">QIFtoLedger</a> (Bank of America's) QIF to *ledger converter</li>
 <li><a href="https://github.com/cantino/reckon">reckon</a> smart interactive/non-interactive CSV to *ledger converter</li>
-<li><a href="https://github.com/marvinpinto/slc">slc</a> slc is a CLI application to generate Ledger accounting entries, works with generic CSV files as well as the Stripe API</li>
+<li><a href="https://github.com/marvinpinto/slc">slc</a> generates Ledger accounting entries, works with generic CSV files as well as the Stripe API</li>
 <li><a href="https://github.com/johannesjh/smart_importer">smart_importer</a> library for building smarter CSV to beancount/Fava converters</li>
 <li><a href="https://github.com/eval/total_recall">total_recall</a> CSV to *ledger converter</li>
 <li><a href="https://github.com/vermiceli/ynab-to-ledger">ynab-to-ledger</a> You Need A Budget (YNAB) to *ledger converter. Handles multiple currencies, multiple number formats, reconciliation, memos, transfers, and split transactions</li>

--- a/index.html
+++ b/index.html
@@ -730,6 +730,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <li><a href="https://gist.github.com/genegoykhman/3765100">qb2ledger</a> QuickBooks General Journal CSV to *ledger converter</li>
 <li><a href="https://github.com/Kolomona/QIFtoLedger">QIFtoLedger</a> (Bank of America's) QIF to *ledger converter</li>
 <li><a href="https://github.com/cantino/reckon">reckon</a> smart interactive/non-interactive CSV to *ledger converter</li>
+<li><a href="https://github.com/marvinpinto/slc">slc</a> slc is a CLI application to generate Ledger accounting entries, works with generic CSV files as well as the Stripe API</li>
 <li><a href="https://github.com/johannesjh/smart_importer">smart_importer</a> library for building smarter CSV to beancount/Fava converters</li>
 <li><a href="https://github.com/eval/total_recall">total_recall</a> CSV to *ledger converter</li>
 <li><a href="https://github.com/vermiceli/ynab-to-ledger">ynab-to-ledger</a> You Need A Budget (YNAB) to *ledger converter. Handles multiple currencies, multiple number formats, reconciliation, memos, transfers, and split transactions</li>

--- a/index.md
+++ b/index.md
@@ -669,6 +669,7 @@ Next, related add-ons and helpers by category
 - [qb2ledger](https://gist.github.com/genegoykhman/3765100) QuickBooks General Journal CSV to *ledger converter
 - [QIFtoLedger](https://github.com/Kolomona/QIFtoLedger) (Bank of America's) QIF to *ledger converter
 - [reckon](https://github.com/cantino/reckon) smart interactive/non-interactive CSV to *ledger converter
+- [slc](https://github.com/marvinpinto/slc) slc is a CLI application to generate Ledger accounting entries, works with generic CSV files as well as the Stripe API
 - [smart_importer](https://github.com/johannesjh/smart_importer) library for building smarter CSV to beancount/Fava converters
 - [total_recall](https://github.com/eval/total_recall) CSV to *ledger converter
 - [ynab-to-ledger](https://github.com/vermiceli/ynab-to-ledger) You Need A Budget (YNAB) to *ledger converter. Handles multiple currencies, multiple number formats, reconciliation, memos, transfers, and split transactions

--- a/index.md
+++ b/index.md
@@ -657,7 +657,6 @@ Next, related add-ons and helpers by category
 - [ledger-autosync](https://gitlab.com/egh/ledger-autosync) OFX download, OFX to *ledger conversion, deduplication
 - [ledger-guesser](https://github.com/j3k0/ledger-guesser) neural network for generating entries like past ones, can be used with ledger-autosync (javascript)
 - [ledger-myexpenses](https://github.com/ony/ledger-myexpenses) MyExpenses android app sqlite db to *ledger conversion (python)
-- [ledger-reconciler](https://disjoint.ca/projects/ledger-reconciler) automatically download and reconcile your ledger financial entries
 - [ledger-to-beancount](https://github.com/glasserc/ledger-to-beancount/) yet another simple ledger to beancount converter (python)
 - [ledger-tutorials](https://github.com/tlvince/ledger-tutorials) convert Pete Keen's tutorials to ebook format
 - [ledger2beancount.py](https://gist.github.com/travisdahlke/71152286b0a8826249fe) *ledger to beancount converter

--- a/index.md
+++ b/index.md
@@ -668,7 +668,7 @@ Next, related add-ons and helpers by category
 - [qb2ledger](https://gist.github.com/genegoykhman/3765100) QuickBooks General Journal CSV to *ledger converter
 - [QIFtoLedger](https://github.com/Kolomona/QIFtoLedger) (Bank of America's) QIF to *ledger converter
 - [reckon](https://github.com/cantino/reckon) smart interactive/non-interactive CSV to *ledger converter
-- [slc](https://github.com/marvinpinto/slc) slc is a CLI application to generate Ledger accounting entries, works with generic CSV files as well as the Stripe API
+- [slc](https://github.com/marvinpinto/slc) generates Ledger accounting entries, works with generic CSV files as well as the Stripe API
 - [smart_importer](https://github.com/johannesjh/smart_importer) library for building smarter CSV to beancount/Fava converters
 - [total_recall](https://github.com/eval/total_recall) CSV to *ledger converter
 - [ynab-to-ledger](https://github.com/vermiceli/ynab-to-ledger) You Need A Budget (YNAB) to *ledger converter. Handles multiple currencies, multiple number formats, reconciliation, memos, transfers, and split transactions

--- a/index1.html
+++ b/index1.html
@@ -456,7 +456,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <li><a href="https://gist.github.com/genegoykhman/3765100">qb2ledger</a> QuickBooks General Journal CSV to *ledger converter</li>
 <li><a href="https://github.com/Kolomona/QIFtoLedger">QIFtoLedger</a> (Bank of America's) QIF to *ledger converter</li>
 <li><a href="https://github.com/cantino/reckon">reckon</a> smart interactive/non-interactive CSV to *ledger converter</li>
-<li><a href="https://github.com/marvinpinto/slc">slc</a> slc is a CLI application to generate Ledger accounting entries, works with generic CSV files as well as the Stripe API</li>
+<li><a href="https://github.com/marvinpinto/slc">slc</a> generates Ledger accounting entries, works with generic CSV files as well as the Stripe API</li>
 <li><a href="https://github.com/johannesjh/smart_importer">smart_importer</a> library for building smarter CSV to beancount/Fava converters</li>
 <li><a href="https://github.com/eval/total_recall">total_recall</a> CSV to *ledger converter</li>
 <li><a href="https://github.com/vermiceli/ynab-to-ledger">ynab-to-ledger</a> You Need A Budget (YNAB) to *ledger converter. Handles multiple currencies, multiple number formats, reconciliation, memos, transfers, and split transactions</li>

--- a/index1.html
+++ b/index1.html
@@ -445,7 +445,6 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <li><a href="https://gitlab.com/egh/ledger-autosync">ledger-autosync</a> OFX download, OFX to *ledger conversion, deduplication</li>
 <li><a href="https://github.com/j3k0/ledger-guesser">ledger-guesser</a> neural network for generating entries like past ones, can be used with ledger-autosync (javascript)</li>
 <li><a href="https://github.com/ony/ledger-myexpenses">ledger-myexpenses</a> MyExpenses android app sqlite db to *ledger conversion (python)</li>
-<li><a href="https://disjoint.ca/projects/ledger-reconciler">ledger-reconciler</a> automatically download and reconcile your ledger financial entries</li>
 <li><a href="https://github.com/glasserc/ledger-to-beancount/">ledger-to-beancount</a> yet another simple ledger to beancount converter (python)</li>
 <li><a href="https://github.com/tlvince/ledger-tutorials">ledger-tutorials</a> convert Pete Keen's tutorials to ebook format</li>
 <li><a href="https://gist.github.com/travisdahlke/71152286b0a8826249fe">ledger2beancount.py</a> *ledger to beancount converter</li>

--- a/index1.html
+++ b/index1.html
@@ -457,6 +457,7 @@ th, td { border:none; padding-top:0; padding-bottom:0; border-bottom:thin solid 
 <li><a href="https://gist.github.com/genegoykhman/3765100">qb2ledger</a> QuickBooks General Journal CSV to *ledger converter</li>
 <li><a href="https://github.com/Kolomona/QIFtoLedger">QIFtoLedger</a> (Bank of America's) QIF to *ledger converter</li>
 <li><a href="https://github.com/cantino/reckon">reckon</a> smart interactive/non-interactive CSV to *ledger converter</li>
+<li><a href="https://github.com/marvinpinto/slc">slc</a> slc is a CLI application to generate Ledger accounting entries, works with generic CSV files as well as the Stripe API</li>
 <li><a href="https://github.com/johannesjh/smart_importer">smart_importer</a> library for building smarter CSV to beancount/Fava converters</li>
 <li><a href="https://github.com/eval/total_recall">total_recall</a> CSV to *ledger converter</li>
 <li><a href="https://github.com/vermiceli/ynab-to-ledger">ynab-to-ledger</a> You Need A Budget (YNAB) to *ledger converter. Handles multiple currencies, multiple number formats, reconciliation, memos, transfers, and split transactions</li>


### PR DESCRIPTION
`slc` is a CLI application to generate Ledger accounting entries, works with generic CSV files as well as the Stripe API.

This also removes `ledger-reconciler` since that project is no-longer maintained.