### PR TITLE
replace superseded  "I Need A Budget" blog

### DIFF
--- a/index.md
+++ b/index.md
@@ -1104,7 +1104,7 @@ and enables thee to stop them and control thy expenditures for definite and grat
 **Envelope budgeting: pre-allocating funds**
 
 - [reddit: New blogpost: Budgeting for annual expenses with Hledger](https://www.reddit.com/r/plaintextaccounting/comments/l9aiup/new_blogpost_budgeting_for_annual_expenses_with/)
-- [Michael Walker: I Need A Budget](https://www.barrucadu.co.uk/posts/etc/2017-12-16-i-need-a-budget.html)
+- [Michael Walker: Personal Finance](https://memo.barrucadu.co.uk/personal-finance.html)
 - [Simon Michael: envelope budgeting example](https://gist.github.com/simonmichael/a1addcb652da4e78b183)
 - [hledger: Budgeting and forecasting: Envelope budget](https://hledger.org/budgeting-and-forecasting.html#envelope-budget)
 


### PR DESCRIPTION
Michael Walker's "I Need A Budget" blog post now leads with

> This memo is superseded. It has been replaced by Personal Finance

Replace the link with one to the new Personal Finance blog post instead.