### PR TITLE
AI: add Claude Code + hledger + Obsidian setup guide

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -824,6 +824,7 @@ td:first-child strong a {
 ### AI
 
 - [accountant24](https://github.com/machulav/accountant24) - local-first multi-model AI agent using hledger
+- [Setup Claude Code to work with hledger and Obsidian](https://www.mandalivia.com/obsidian/hledger-obsidian-personal-finance-with-claude-code/) - Claude Code as the agent layer for hledger in an Obsidian vault
 
 ### Distros/setups
 


### PR DESCRIPTION
Add a Claude Code + hledger + Obsidian setup guide to the AI section.

Sits alongside accountant24 as a second entry in the section. accountant24 is a tool you install; this is a setup recipe for using an existing tool (Claude Code) with hledger inside an Obsidian vault.

Disclosing: I wrote the linked guide. Happy to drop or revise.