### PR TITLE
Add Countbean to the AI section

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -832,6 +832,7 @@ td:first-child strong a {
 
 - [accountant24](https://github.com/machulav/accountant24) - local-first multi-model AI agent using hledger
 - [Setup Claude Code to work with hledger and Obsidian](https://www.mandalivia.com/obsidian/hledger-obsidian-personal-finance-with-claude-code/) - Claude Code as the agent layer for hledger in an Obsidian vault
+- [Countbean](https://github.com/CPUtester5465/countbean-plugin) - Claude Code plugin and MCP server for Beancount: turns plain English into double-entry transactions, runs bean-check, and commits each change to git so it can be diffed and reverted. Works on a local ledger file, or on a hosted book.
 
 ### Distros/setups
 


### PR DESCRIPTION
Adds one entry to `### AI`.

[Countbean](https://github.com/CPUtester5465/countbean-plugin) is a Claude Code plugin and MCP server for Beancount (MIT). It exposes the ledger as MCP tools so an assistant can turn plain English into double-entry transactions, runs `bean-check`, and commits each change to git so it can be diffed and reverted.

It works against a plain local ledger file with no account, which is what I think makes it relevant here. There is also a hosted option, which I have kept out of the entry — the link goes to the open-source plugin, not to a marketing page.

The section currently has two hledger-oriented entries and nothing for Beancount, so I hope this is additive rather than noise. Happy to reword or drop it if it is not a fit.